### PR TITLE
Add package write permissions to publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master


### PR DESCRIPTION
The workflow to publish bottles requires the right permissions to create github packages:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions
